### PR TITLE
fix:pass `get_ast_nodes` instead of its return value to leap

### DIFF
--- a/lua/leap-ast.lua
+++ b/lua/leap-ast.lua
@@ -42,7 +42,7 @@ end
 
 local function leap()
   require('leap').leap {
-    targets = get_ast_nodes(),
+    targets = get_ast_nodes,
     action = api.nvim_get_mode().mode ~= 'n' and select_range,  -- or jump
     backward = true
   }


### PR DESCRIPTION
This avoids passing TS nodes (which are userdata) to `nvim_exec_autocmds()`. Since some time ago, it seems to convert its arguments to Vim objects, which fails on userdata.